### PR TITLE
Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -27,12 +27,10 @@ coverage:
         branches: null
 
   ignore:
-    - test/.*
+    - test/*
     - .github/*
 
 comment:
   layout: "header, diff, changes, uncovered"
-  branches: "*"
+  branches: null
   behavior: default
-  paths:
-    - src/.*

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "babel src --presets babel-preset-es2015 --out-dir dist",
-    "codecov": "babel-node ./node_modules/istanbul/lib/cli.js cover ./node_modules/.bin/_mocha -- test --recursive && codecov",
+    "codecov": "istanbul cover ./node_modules/.bin/_mocha -- test --recursive --compilers js:babel-register && codecov",
     "prepublish": "npm run build",
     "test": "mocha --compilers js:babel-register test",
     "lint": "eslint --ext '.js' ./src"
@@ -36,7 +36,7 @@
     "eslint-config-eslint": "^3.0.0",
     "eslint-plugin-import": "^1.8.1",
     "expect": "^1.20.1",
-    "istanbul": "^0.4.4",
+    "istanbul": "1.0.0-alpha.2",
     "jsdom": "^9.2.1",
     "mocha": "^2.4.5",
     "mocha-jsdom": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,11 @@
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
-    "babel-core": "^6.7.7",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.9.0",
     "codecov": "^1.0.1",
     "eslint": "^2.11.1",
     "eslint-config-airbnb-base": "^3.0.1",
-    "eslint-config-eslint": "^3.0.0",
     "eslint-plugin-import": "^1.8.1",
     "expect": "^1.20.1",
     "istanbul": "1.0.0-alpha.2",

--- a/test/docsSoapSpec.js
+++ b/test/docsSoapSpec.js
@@ -2,7 +2,7 @@
 
 import { elements } from '../src/constants'
 import documents from './fixtures/documents';
-import docsSoap from '../dist/index';
+import docsSoap from '../src/index';
 import expect from 'expect';
 import jsdom from 'mocha-jsdom';
 import parseHTML from '../src/parseHTML';


### PR DESCRIPTION
fixes codecov, updates istanbul to the 1.0.0 alpha to properly handle es6 code
