### PR TITLE
Add flow type checking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
- "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["transform-flow-strip-types"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,29 @@
 {
+  "parser": "babel-eslint",
   "extends": "airbnb-base",
   "rules": {
     "comma-dangle": 0,
-    "max-len": 0
-  }
+    "max-len": 0,
+    "flowtype/require-parameter-type": 1,
+    "flowtype/require-return-type": [
+      1,
+      "always",
+      {
+        "annotateUndefined": "never"
+      }
+    ],
+    "flowtype/space-after-type-colon": [
+      1,
+      "always"
+    ],
+    "flowtype/space-before-type-colon": [
+      1,
+      "never"
+    ],
+    "flowtype/type-id-match": [
+      1,
+      "^([A-Z][a-z0-9]+)+Type$"
+    ]
+  },
+  "plugins": ["flowtype"]
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+  suppress_comment= \\(.\\|\n\\)*\\flow-ignore

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 npm-debug.log
 node_modules
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
 script:
   - npm run build
   - npm run lint
+  - npm run flow
   - npm run test
   - npm run codecov

--- a/package.json
+++ b/package.json
@@ -23,17 +23,22 @@
     "codecov": "istanbul cover ./node_modules/.bin/_mocha -- test --recursive --compilers js:babel-register && codecov",
     "prepublish": "npm run build",
     "test": "mocha --compilers js:babel-register test",
-    "lint": "eslint --ext '.js' ./src"
+    "lint": "eslint --ext '.js' ./src",
+    "flow": "flow"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "babel-eslint": "^6.1.0",
+    "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.9.0",
     "codecov": "^1.0.1",
     "eslint": "^2.11.1",
     "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-flowtype": "^2.3.0",
     "eslint-plugin-import": "^1.8.1",
     "expect": "^1.20.1",
+    "flow-bin": "^0.28.0",
     "istanbul": "1.0.0-alpha.2",
     "jsdom": "^9.2.1",
     "mocha": "^2.4.5",

--- a/src/docsSoap.js
+++ b/src/docsSoap.js
@@ -1,20 +1,31 @@
+// @flow
+
 import { docsId, elements, styles } from './constants';
 import parseHTML from './parseHTML';
 
-const wrapNodeAnchor = (node, href) => {
+const wrapNodeAnchor = (
+  node: Node,
+  href: string
+): HTMLAnchorElement => {
   const anchor = document.createElement(elements.ANCHOR);
   anchor.href = href;
   anchor.appendChild(node.cloneNode(true));
   return anchor;
 };
 
-const wrapNodeInline = (node, style) => {
+const wrapNodeInline = (
+  node: Node,
+  style: string
+): Node => {
   const el = document.createElement(style);
   el.appendChild(node.cloneNode(true));
   return el;
 };
 
-const wrapNode = (inner, result) => {
+const wrapNode = (
+  inner: Node,
+  result: Node
+): Node => {
   let newNode = result.cloneNode(true);
   if (inner.style && inner.style.fontWeight === styles.BOLD) {
     newNode = wrapNodeInline(newNode, elements.BOLD);
@@ -37,14 +48,17 @@ const wrapNode = (inner, result) => {
   return newNode;
 };
 
-const applyBlockStyles = dirty => {
+const applyBlockStyles = (
+  dirty: Node
+): Node => {
   const node = dirty.cloneNode(true);
   let newNode = document.createTextNode(node.textContent);
-  let styledNode = null;
+  let styledNode = document.createTextNode('');
   if (node.childNodes[0] && node.childNodes[0].style) {
     styledNode = node.childNodes[0];
   }
   if (node.childNodes[0] && node.childNodes[0].nodeName === 'A') {
+    // flow-ignore Flow doesn't recognize that a childNode can be an HTMLAnchorElement
     newNode = wrapNodeAnchor(newNode.cloneNode(true), node.childNodes[0].href);
     styledNode = node.childNodes[0].childNodes[0];
   }
@@ -52,11 +66,14 @@ const applyBlockStyles = dirty => {
   return newNode;
 };
 
-const applyInlineStyles = dirty => {
+const applyInlineStyles = (
+  dirty: Node
+): Node => {
   const node = dirty.cloneNode(true);
   let newNode = document.createTextNode(node.textContent);
   let styledNode = node;
   if (node.nodeName === 'A') {
+    // flow-ignore Flow doesn't recognize that cloneNode() can return an HTMLAnchorElement
     newNode = wrapNodeAnchor(newNode, node.href);
     if (node.childNodes[0] && node.childNodes[0].style) {
       styledNode = node.childNodes[0];
@@ -66,7 +83,9 @@ const applyInlineStyles = dirty => {
   return newNode;
 };
 
-const getCleanNode = (node) => {
+const getCleanNode = (
+  node: Node
+): Array<Node> => {
   if (node.childNodes && node.childNodes.length <= 1) {
     let newWrapper = null;
     let newNode = document.createTextNode(node.textContent);
@@ -94,7 +113,7 @@ const getCleanNode = (node) => {
     }
     return nodes;
   }
-  return node;
+  return [node];
 };
 
 /**
@@ -103,7 +122,9 @@ const getCleanNode = (node) => {
  * @param dirty
  * @returns {HTMLElement}
  */
-const getCleanDocument = (dirty) => {
+const getCleanDocument = (
+  dirty: HTMLElement
+): HTMLElement => {
   // create a new document to preserve the integrity of the original data
   const body = document.createElement('body');
   const nodes = dirty.childNodes;
@@ -123,7 +144,9 @@ const getCleanDocument = (dirty) => {
   return body;
 };
 
-module.exports = (clipboardContent) => {
+module.exports = (
+  clipboardContent: string
+): string => {
   if (typeof clipboardContent !== 'string') {
     throw new Error(`Expected 'clipboardContent' to be a string of HTML, received ${typeof clipboardContent}`);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 const docsSoap = require('./docsSoap');
 const parseHTML = require('./parseHTML');
 

--- a/src/parseHTML.js
+++ b/src/parseHTML.js
@@ -1,4 +1,8 @@
-module.exports = function parseHTML(html) {
+// @flow
+
+module.exports = (
+  html: string
+): HTMLElement => {
   let doc = void 0;
   if (typeof DOMParser !== 'undefined') {
     const parser = new DOMParser();


### PR DESCRIPTION
Closes #13 

There are two ignored lines where we can't typecheck properly because Flow doesn't believe that nodes using `Node#cloneNode` can have an `href` attribute, nor does Flow accept that `typeof Node.childNodes[x] !== Node` can resolve to true. I may look into opening an issue about why those assumptions were made. 

Heads up @LeZuse you may want to pull this code in, don't want you to get too far into your changes and then run into conflicts
